### PR TITLE
Update configuration.md with outDir

### DIFF
--- a/config/configuration.md
+++ b/config/configuration.md
@@ -65,7 +65,8 @@ module.exports = {
   publishers: [],
   plugins: [],
   hooks: { /* ... */ },
-  buildIdentifier: 'my-build'
+  buildIdentifier: 'my-build',
+  outDir: 'desired/outpath'
 };
 ```
 {% endtab %}
@@ -82,7 +83,8 @@ module.exports = {
       "publishers": [ ... ],
       "plugins": [ ... ],
       "hooks": { ... },
-      "buildIdentifier": "my-build"
+      "buildIdentifier": "my-build",
+      "outDir": "desired/outpath"
     }
   }
 }


### PR DESCRIPTION
Add documentation of custom output directory in either the package.json or forge.config.js locations that was added in electron/forge#3458.